### PR TITLE
Rename compile to validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Context Mapper CLI
 [![Build (master)](https://github.com/ContextMapper/context-mapper-cli/actions/workflows/build_master.yml/badge.svg)](https://github.com/ContextMapper/context-mapper-cli/actions) [![codecov](https://codecov.io/gh/ContextMapper/context-mapper-cli/branch/master/graph/badge.svg?token=OMqxkddZOJ)](https://codecov.io/gh/ContextMapper/context-mapper-cli) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Maven Central](https://img.shields.io/maven-central/v/org.contextmapper/context-mapper-cli.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22org.contextmapper%22%20AND%20a:%22context-mapper-cli%22)
 
-This repository contains the Context Mapper CLI - a command line interface to compile CML files and call generators
+This repository contains the Context Mapper CLI - a command line interface to validate CML files and call generators
 (currently PlantUML, Context Map, and generic text files via Freemarker template).
 
 ## Download
@@ -26,13 +26,13 @@ implementation 'org.contextmapper:context-mapper-cli:6.6.1'
 </dependency>
 ```
 
-## Compile Command Usage
+## Validate Command Usage
 ```shell
-$ ./cm compile -h
+$ ./cm validate -h
 Context Mapper CLI
-usage: cm compile
+usage: cm validate
  -h,--help          Prints this message.
- -i,--input <arg>   Path to the CML file which you want to compile.
+ -i,--input <arg>   Path to the CML file which you want to validate.
 ```
 
 ## Generate Command Usage
@@ -61,10 +61,10 @@ usage: cm generate
 ## Usage examples
 The following examples illustrate the CLI usage.
 
-### Compile/Validate *.cml File
+### Validate *.cml File
 
 ```shell
-./cm compile -i DDD-Sample.cml
+./cm validate -i DDD-Sample.cml
 ```
 
 ### Generate PlantUML

--- a/src/main/java/org/contextmapper/cli/ContextMapperCLI.java
+++ b/src/main/java/org/contextmapper/cli/ContextMapperCLI.java
@@ -16,22 +16,22 @@
 package org.contextmapper.cli;
 
 import org.contextmapper.cli.commands.CliCommand;
-import org.contextmapper.cli.commands.CompileCommand;
 import org.contextmapper.cli.commands.GenerateCommand;
+import org.contextmapper.cli.commands.ValidateCommand;
 
 import java.util.Arrays;
 
 public class ContextMapperCLI {
 
-    private static final String COMPILE_COMMAND = "compile";
+    private static final String VALIDATE_COMMAND = "validate";
     private static final String GENERATE_COMMAND = "generate";
 
     private CliCommand generateCommand;
-    private CliCommand compileCommand;
+    private CliCommand validateCommand;
 
     public ContextMapperCLI() {
         this.generateCommand = new GenerateCommand();
-        this.compileCommand = new CompileCommand();
+        this.validateCommand = new ValidateCommand();
     }
 
     public static void main(String[] args) {
@@ -43,15 +43,15 @@ public class ContextMapperCLI {
 
         if (args == null || args.length == 0) {
             printUsages();
-        } else if (COMPILE_COMMAND.equalsIgnoreCase(args[0])) {
-            compileCommand.run(Arrays.copyOfRange(args, 1, args.length));
+        } else if (VALIDATE_COMMAND.equalsIgnoreCase(args[0])) {
+            validateCommand.run(Arrays.copyOfRange(args, 1, args.length));
         } else if (GENERATE_COMMAND.equalsIgnoreCase(args[0])) {
             generateCommand.run(Arrays.copyOfRange(args, 1, args.length));
         }
     }
 
     private void printUsages() {
-        System.out.println("Usage: cm " + COMPILE_COMMAND + "|" + GENERATE_COMMAND + " [options]");
+        System.out.println("Usage: cm " + VALIDATE_COMMAND + "|" + GENERATE_COMMAND + " [options]");
     }
 
     private String getVersion() {

--- a/src/main/java/org/contextmapper/cli/commands/ValidateCommand.java
+++ b/src/main/java/org/contextmapper/cli/commands/ValidateCommand.java
@@ -21,7 +21,7 @@ import org.contextmapper.dsl.standalone.ContextMapperStandaloneSetup;
 import org.contextmapper.dsl.standalone.StandaloneContextMapperAPI;
 import org.eclipse.emf.ecore.resource.Resource.Diagnostic;
 
-public class CompileCommand extends AbstractCliCommand {
+public class ValidateCommand extends AbstractCliCommand {
 
     @Override
     public void run(String[] args) {
@@ -58,7 +58,7 @@ public class CompileCommand extends AbstractCliCommand {
         Option help = new Option("h", "help", false, "Prints this message.");
         options.addOption(help);
 
-        Option input = new Option("i", "input", true, "Path to the CML file which you want to compile.");
+        Option input = new Option("i", "input", true, "Path to the CML file which you want to validate.");
         input.setRequired(true);
         options.addOption(input);
 
@@ -67,7 +67,7 @@ public class CompileCommand extends AbstractCliCommand {
 
     protected void printValidationMessages(final CMLResource cmlResource, final String filePath) {
         if (cmlResource.getErrors().isEmpty()) {
-            System.out.println("The CML file '" + filePath + "' has been compiled without errors.");
+            System.out.println("The CML file '" + filePath + "' has been validated without errors.");
         } else {
             for (Diagnostic diagnostic : cmlResource.getErrors()) {
                 System.out.println("ERROR in " + diagnostic.getLocation() + " on line " + diagnostic.getLine() + ":"
@@ -82,7 +82,7 @@ public class CompileCommand extends AbstractCliCommand {
     }
 
     protected void printHelp(final Options options) {
-        new HelpFormatter().printHelp("cm compile", options);
+        new HelpFormatter().printHelp("cm validate", options);
     }
 
 }

--- a/src/test/java/org/contextmapper/cli/ContextMapperCLITest.java
+++ b/src/test/java/org/contextmapper/cli/ContextMapperCLITest.java
@@ -15,8 +15,8 @@
  */
 package org.contextmapper.cli;
 
-import org.contextmapper.cli.commands.CompileCommand;
 import org.contextmapper.cli.commands.GenerateCommand;
+import org.contextmapper.cli.commands.ValidateCommand;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,7 +40,7 @@ class ContextMapperCLITest {
     private final PrintStream originalErr = System.err;
 
     @Mock
-    private CompileCommand compileCommand;
+    private ValidateCommand validateCommand;
 
     @Mock
     private GenerateCommand generateCommand;
@@ -70,7 +70,7 @@ class ContextMapperCLITest {
 
         // then
         assertThat(outContent.toString()).isEqualTo("Context Mapper CLI DEVELOPMENT VERSION" + System.lineSeparator() +
-                "Usage: cm compile|generate [options]" + System.lineSeparator());
+                "Usage: cm validate|generate [options]" + System.lineSeparator());
     }
 
     @Test
@@ -83,31 +83,31 @@ class ContextMapperCLITest {
 
         // then
         assertThat(outContent.toString()).isEqualTo("Context Mapper CLI DEVELOPMENT VERSION" + System.lineSeparator() +
-                "Usage: cm compile|generate [options]" + System.lineSeparator());
+                "Usage: cm validate|generate [options]" + System.lineSeparator());
     }
 
     @Test
-    void run_WhenCalledWithCompile_ThenCallCompileCommand() {
+    void run_WhenCalledWithValidate_ThenCallValidateCommand() {
         // given
-        final String[] params = new String[]{"compile"};
+        final String[] params = new String[]{"validate"};
 
         // when
         contextMapperCLI.run(params);
 
         // then
-        verify(compileCommand).run(new String[]{});
+        verify(validateCommand).run(new String[]{});
     }
 
     @Test
-    void run_WhenCalledWithCompileAndAdditionalParams_ThenCallCompileCommandWithParams() {
+    void run_WhenCalledWithValidateAndAdditionalParams_ThenCallValidateCommandWithParams() {
         // given
-        final String[] params = new String[]{"compile", "test-param"};
+        final String[] params = new String[]{"validate", "test-param"};
 
         // when
         contextMapperCLI.run(params);
 
         // then
-        verify(compileCommand).run(new String[]{"test-param"});
+        verify(validateCommand).run(new String[]{"test-param"});
     }
 
     @Test

--- a/src/test/java/org/contextmapper/cli/commands/ValidateCommandTest.java
+++ b/src/test/java/org/contextmapper/cli/commands/ValidateCommandTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-class CompileCommandTest {
+class ValidateCommandTest {
 
     private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
     private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
@@ -53,7 +53,7 @@ class CompileCommandTest {
     @ValueSource(strings = {"-h", "--help", "-i some-file.cml -h", "-i some-file.cml --help"})
     void run_WhenCalledWithHelp_ThenPrintHelp(final String params) {
         // given
-        final CompileCommand command = spy(new CompileCommand());
+        final ValidateCommand command = spy(new ValidateCommand());
 
         // when
         command.run(params.split(" "));
@@ -63,22 +63,22 @@ class CompileCommandTest {
     }
 
     @Test
-    void run_WhenWithValidCMLFile_ThenCompileWithoutErrors() {
+    void run_WhenWithValidCMLFile_ThenValidateWithoutErrors() {
         // given
-        final CompileCommand command = spy(new CompileCommand());
+        final ValidateCommand command = spy(new ValidateCommand());
 
         // when
         command.run(new String[]{"-i src/test/resources/test.cml"});
 
         // then
         verify(command).printValidationMessages(any(), any());
-        assertThat(outContent.toString()).contains("The CML file 'src/test/resources/test.cml' has been compiled without errors.");
+        assertThat(outContent.toString()).contains("The CML file 'src/test/resources/test.cml' has been validated without errors.");
     }
 
     @Test
     void run_WhenWithInvalidCMLFile_ThenPrintError() {
         // given
-        final CompileCommand command = spy(new CompileCommand());
+        final ValidateCommand command = spy(new ValidateCommand());
 
         // when
         command.run(new String[]{"-i src/test/resources/test-with-error.cml"});


### PR DESCRIPTION
Rename the `compile` command to `validate` to reflect closer what it does.