### PR TITLE
Fix for resolve paths in cli

### DIFF
--- a/src/main/java/org/contextmapper/cli/commands/GenerateCommand.java
+++ b/src/main/java/org/contextmapper/cli/commands/GenerateCommand.java
@@ -21,6 +21,7 @@ import org.contextmapper.dsl.generator.GenericContentGenerator;
 import org.contextmapper.dsl.standalone.ContextMapperStandaloneSetup;
 import org.contextmapper.dsl.standalone.StandaloneContextMapperAPI;
 import org.eclipse.xtext.generator.IGenerator2;
+import org.contextmapper.dsl.cml.CMLImportResolver;
 
 import java.io.File;
 import java.util.Arrays;
@@ -51,7 +52,12 @@ public class GenerateCommand extends AbstractCliCommand {
 
                 if (doesOutputDirExist(this.outputDir)) {
                     StandaloneContextMapperAPI cmAPI = ContextMapperStandaloneSetup.getStandaloneAPI();
-                    CMLResource cmlResource = cmAPI.loadCML(inputPath);
+                    File inputFile = new File(inputPath).getAbsoluteFile();
+                    CMLResource cmlResource = cmAPI.loadCML(inputFile);
+                    
+                    // Ensure imports are resolved before generation
+                    new CMLImportResolver().resolveImportedResources(cmlResource);
+                    
                     cmAPI.callGenerator(cmlResource, getGenerator(cmd), this.outputDir);
                     System.out.println("Generated into '" + this.outputDir + "'.");
                 }

--- a/src/test/java/org/contextmapper/cli/commands/GenerateCommandTest.java
+++ b/src/test/java/org/contextmapper/cli/commands/GenerateCommandTest.java
@@ -138,6 +138,22 @@ class GenerateCommandTest {
     }
 
     @Test
+    void run_WhenCalledWithFileContainingImports_ThenGenerateFilesWithImportedContexts() throws IOException {
+        // given
+        final GenerateCommand command = spy(new GenerateCommand());
+        new File("build/test-out").mkdir();
+
+        // when
+        command.run(new String[]{"-i", "src/test/resources/test-with-imports.cml", "-g", "context-map", "-o", "build/test-out"});
+
+        // then
+        assertThat(outContent.toString()).contains("Generated into 'build/test-out'.");
+        assertThat(new File("build/test-out/test-with-imports_ContextMap.gv").exists()).isTrue();
+        assertThat(new File("build/test-out/test-with-imports_ContextMap.png").exists()).isTrue();
+        assertThat(new File("build/test-out/test-with-imports_ContextMap.svg").exists()).isTrue();
+    }
+
+    @Test
     void run_WhenCalledWithGenericParam_ThenGenerateGenericOutput() {
         // given
         final GenerateCommand command = spy(new GenerateCommand());

--- a/src/test/java/org/contextmapper/cli/commands/ValidateCommandTest.java
+++ b/src/test/java/org/contextmapper/cli/commands/ValidateCommandTest.java
@@ -88,4 +88,17 @@ class ValidateCommandTest {
         assertThat(outContent.toString()).contains("ERROR in null on line 2:mismatched input '<EOF>' expecting RULE_CLOSE");
     }
 
+    @Test
+    void run_WhenWithFileContainingImports_ThenValidateWithoutErrors() {
+        // given
+        final ValidateCommand command = spy(new ValidateCommand());
+
+        // when
+        command.run(new String[]{"-i src/test/resources/test-with-imports.cml"});
+
+        // then
+        verify(command).printValidationMessages(any(), any());
+        assertThat(outContent.toString()).contains("The CML file 'src/test/resources/test-with-imports.cml' has been validated without errors.");
+    }
+
 }

--- a/src/test/resources/other-contexts.cml
+++ b/src/test/resources/other-contexts.cml
@@ -1,0 +1,3 @@
+/* Simple bounded contexts */
+BoundedContext anotherContext
+BoundedContext yetAnotherContext 

--- a/src/test/resources/test-with-imports.cml
+++ b/src/test/resources/test-with-imports.cml
@@ -1,0 +1,8 @@
+/* Import other contexts */
+import "./other-contexts.cml"
+
+/* Define a simple context map */
+ContextMap SimpleMap {
+  contains anotherContext
+  contains yetAnotherContext
+} 


### PR DESCRIPTION
Ref: https://github.com/ContextMapper/context-mapper-cli/issues/14

The CLI project now properly handles imports in CML files by:
1. Using CMLImportResolver to explicitly resolve imports
2. Using absolute file paths to ensure correct URI resolution
3. Updating test files to match DSL project's import syntax

This aligns the CLI's import handling with the DSL project's implementation.